### PR TITLE
update mouse orbit sensitivity 

### DIFF
--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -66,9 +66,9 @@ pub struct OrbitCameraController {
 impl Default for OrbitCameraController {
     fn default() -> Self {
         Self {
-            mouse_rotate_sensitivity: Vec2::splat(0.002),
-            mouse_translate_sensitivity: Vec2::splat(0.1),
-            mouse_wheel_zoom_sensitivity: 0.001,
+            mouse_rotate_sensitivity: Vec2::splat(0.006),
+            mouse_translate_sensitivity: Vec2::splat(0.008),
+            mouse_wheel_zoom_sensitivity: 0.15,
             smoothing_weight: 0.8,
             enabled: true,
         }


### PR DESCRIPTION
based on having the mouse movement reflect the amount of pan, or rotation, 1-to-1 afaict. 
zooming was also set very low.