### PR TITLE
Flipped zoom scroll axis

### DIFF
--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -124,7 +124,7 @@ pub fn default_input_map(
 
     let mut scalar = 1.0;
     for event in mouse_wheel_reader.iter() {
-        scalar *= 1.0 + event.y * mouse_wheel_zoom_sensitivity;
+        scalar *= 1.0 + -event.y * mouse_wheel_zoom_sensitivity;
     }
     events.send(ControlEvent::Zoom(scalar));
 }


### PR DESCRIPTION
This might be a niche thing but when you scroll up, the default behavior is usually zooming in. The `OrbitCamera` controller zooms out when scrolling up. This pr has the scroll axis flipped.