### PR TITLE
Scale wheel event value according to whether they're lines or pixels

### DIFF
--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -141,7 +141,7 @@ pub fn default_input_map(
 
     let mut scalar = 1.0;
     for event in mouse_wheel_reader.iter() {
-        // scale the event magnitude per pixel or per line, assuming 50 pixels per line
+        // scale the event magnitude per pixel or per line
         let scroll_amount = match event.unit {
             MouseScrollUnit::Line => event.y,
             MouseScrollUnit::Pixel => event.y / pixels_per_line,


### PR DESCRIPTION
When using this with bevy in the browser, this previously would give some whacky behavior with the scroll wheel. Previously, this library was just using `event.y`, which was 53 on my machine. When I ran with a desktop backend, it was using `Line`, so it was just feeding back 1, so I assume that's what you were testing with because that looked fine.