### PR TITLE
Match UE4 viewport controls for unreal module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.idea

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -28,11 +28,9 @@ impl UnrealCameraPlugin {
 
 impl Plugin for UnrealCameraPlugin {
     fn build(&self, app: &mut App) {
-        let app = app
-            .add_system(control_system)
-            .add_event::<ControlEvent>();
+        let app = app.add_system(apply_inputs).add_event::<ControlEvent>();
         if !self.override_input_system {
-            app.add_system(default_input_map);
+            app.add_system(process_inputs);
         }
     }
 }
@@ -70,10 +68,26 @@ impl UnrealCameraBundle {
 /// A camera controlled with the mouse in the same way as Unreal Engine's viewport controller.
 #[derive(Clone, Component, Copy, Debug, Deserialize, Serialize)]
 pub struct UnrealCameraController {
+    /// Whether to process input or ignore it
     pub enabled: bool,
-    pub mouse_rotate_sensitivity: Vec2,
+
+    /// How many radians per frame for each rotation axis (yaw, pitch) when rotating with the mouse
+    pub rotate_sensitivity: Vec2,
+
+    /// How many units per frame for each direction when translating using Middle or L+R panning
     pub mouse_translate_sensitivity: Vec2,
-    pub trackpad_translate_sensitivity: Vec2,
+
+    /// How many units per frame when translating using scroll wheel
+    pub wheel_translate_sensitivity: f32,
+
+    /// How many units per frame when translating using W/S/Q/E
+    /// Updated with scroll wheel while dragging with any mouse button
+    pub keyboard_mvmt_sensitivity: f32,
+
+    /// Wheel sensitivity for modulating keyboard movement speed
+    pub keyboard_mvmt_wheel_sensitivity: f32,
+
+    /// The greater, the slower to follow input
     pub smoothing_weight: f32,
 }
 
@@ -81,38 +95,43 @@ impl Default for UnrealCameraController {
     fn default() -> Self {
         Self {
             enabled: true,
-            mouse_rotate_sensitivity: Vec2::splat(0.002),
-            mouse_translate_sensitivity: Vec2::splat(0.1),
-            trackpad_translate_sensitivity: Vec2::splat(0.1),
-            smoothing_weight: 0.9,
+            rotate_sensitivity: Vec2::splat(0.002),
+            mouse_translate_sensitivity: Vec2::splat(0.02),
+            wheel_translate_sensitivity: 1.0,
+            keyboard_mvmt_sensitivity: 0.1,
+            keyboard_mvmt_wheel_sensitivity: 0.1,
+            smoothing_weight: 0.7,
         }
     }
 }
 
-pub enum ControlEvent {
+enum ControlEvent {
     Locomotion(Vec2),
     Rotate(Vec2),
     TranslateEye(Vec2),
 }
 
-pub fn default_input_map(
+fn process_inputs(
     mut events: EventWriter<ControlEvent>,
     mut mouse_wheel_reader: EventReader<MouseWheel>,
     mut mouse_motion_events: EventReader<MouseMotion>,
+    keyboard: Res<Input<KeyCode>>,
     mouse_buttons: Res<Input<MouseButton>>,
-    controllers: Query<&UnrealCameraController>,
+    mut controllers: Query<&mut UnrealCameraController>,
 ) {
     // Can only control one camera at a time.
-    let controller = if let Some(controller) = controllers.iter().next() {
+    let mut controller = if let Some(controller) = controllers.iter_mut().next() {
         controller
     } else {
         return;
     };
     let UnrealCameraController {
         enabled,
+        rotate_sensitivity: mouse_rotate_sensitivity,
         mouse_translate_sensitivity,
-        mouse_rotate_sensitivity,
-        trackpad_translate_sensitivity,
+        wheel_translate_sensitivity,
+        mut keyboard_mvmt_sensitivity,
+        keyboard_mvmt_wheel_sensitivity,
         ..
     } = *controller;
 
@@ -120,46 +139,100 @@ pub fn default_input_map(
         return;
     }
 
+    let left_pressed = mouse_buttons.pressed(MouseButton::Left);
+    let right_pressed = mouse_buttons.pressed(MouseButton::Right);
+    let middle_pressed = mouse_buttons.pressed(MouseButton::Middle);
+
     let mut cursor_delta = Vec2::ZERO;
     for event in mouse_motion_events.iter() {
         cursor_delta += event.delta;
     }
 
-    match (
-        mouse_buttons.pressed(MouseButton::Left),
-        mouse_buttons.pressed(MouseButton::Right),
-    ) {
-        (true, true) => {
-            events.send(ControlEvent::TranslateEye(
-                mouse_translate_sensitivity * cursor_delta,
-            ));
-        }
-        (true, false) => {
-            events.send(ControlEvent::Locomotion(Vec2::new(
-                mouse_rotate_sensitivity.x * cursor_delta.x,
-                mouse_translate_sensitivity.y * cursor_delta.y,
-            )));
-        }
-        (false, true) => {
-            events.send(ControlEvent::Rotate(
-                mouse_rotate_sensitivity * cursor_delta,
-            ));
-        }
-        _ => (),
+    let mut wheel_delta = 0.0;
+    for event in mouse_wheel_reader.iter() {
+        wheel_delta += event.x + event.y;
     }
 
-    // On Mac, mouse wheel is the trackpad, treated the same as both mouse buttons down.
-    let mut trackpad_delta = Vec2::ZERO;
-    for event in mouse_wheel_reader.iter() {
-        trackpad_delta.x += event.x;
-        trackpad_delta.y += event.y;
+    let mut panning_dir = Vec2::ZERO;
+    let mut translation_dir = Vec2::ZERO; // y is forward/backward axis, x is rotation around Z
+
+    for key in keyboard.get_pressed() {
+        match key {
+            KeyCode::E => {
+                panning_dir.y += 1.0;
+            }
+
+            KeyCode::Q => {
+                panning_dir.y -= 1.0;
+            }
+
+            KeyCode::A => {
+                panning_dir.x -= 1.0;
+            }
+
+            KeyCode::D => {
+                panning_dir.x += 1.0;
+            }
+
+            KeyCode::S => {
+                translation_dir.y -= 1.0;
+            }
+
+            KeyCode::W => {
+                translation_dir.y += 1.0;
+            }
+
+            _ => {}
+        }
     }
-    events.send(ControlEvent::TranslateEye(
-        trackpad_translate_sensitivity * trackpad_delta,
-    ));
+
+    let mut panning = Vec2::ZERO;
+    let mut locomotion = Vec2::ZERO;
+
+    // If any of the mouse button are pressed; read additional signals from the keyboard for panning
+    // and locomotion along camera view axis
+    if left_pressed || middle_pressed || right_pressed {
+        panning += keyboard_mvmt_sensitivity * panning_dir;
+
+        if translation_dir.y != 0.0 {
+            locomotion.y += keyboard_mvmt_sensitivity * translation_dir.y;
+        }
+
+        keyboard_mvmt_sensitivity += keyboard_mvmt_wheel_sensitivity * wheel_delta;
+        controller.keyboard_mvmt_sensitivity = keyboard_mvmt_sensitivity.max(0.01);
+    }
+    // Otherwise, if any scrolling is happening, do locomotion along camera view axis
+    else if wheel_delta != 0.0 {
+        locomotion.y += wheel_translate_sensitivity * wheel_delta;
+    }
+
+    // You can also pan using the mouse only; add those signals to existing panning
+    if middle_pressed || (left_pressed && right_pressed) {
+        panning += mouse_translate_sensitivity * cursor_delta;
+    }
+
+    // When left only is pressed, mouse movements add up to the "unreal locomotion" scheme
+    if left_pressed && !middle_pressed && !right_pressed {
+        locomotion.x = mouse_rotate_sensitivity.x * cursor_delta.x;
+        locomotion.y -= mouse_translate_sensitivity.y * cursor_delta.y;
+    }
+
+    if !left_pressed && !middle_pressed && right_pressed {
+        events.send(ControlEvent::Rotate(
+            mouse_rotate_sensitivity * cursor_delta,
+        ));
+    }
+
+    if panning.length_squared() > 0.0 {
+        events.send(ControlEvent::TranslateEye(panning));
+    }
+
+    if locomotion.length_squared() > 0.0 {
+        events.send(ControlEvent::Locomotion(locomotion));
+    }
 }
 
-pub fn control_system(
+fn apply_inputs(
     mut events: EventReader<ControlEvent>,
     mut cameras: Query<(&UnrealCameraController, &mut LookTransform)>,
 ) {
@@ -172,20 +245,19 @@ pub fn control_system(
         };
 
     if controller.enabled {
-        let look_vector = transform.look_direction().unwrap();
+        let look_vector;
+        match transform.look_direction() {
+            Some(safe_look_vector) => look_vector = safe_look_vector,
+            None => return,
+        }
         let mut look_angles = LookAngles::from_vector(look_vector);
-        let forward_vector = Vec3::new(look_vector.x, 0.0, look_vector.z).normalize();
-
-        let yaw_rot = Quat::from_axis_angle(Vec3::Y, look_angles.get_yaw());
-        let rot_x = yaw_rot * Vec3::X;
-        let rot_y = yaw_rot * Vec3::Y;
 
         for event in events.iter() {
             match event {
                 ControlEvent::Locomotion(delta) => {
                     // Translates forward/backward and rotates about the Y axis.
                     look_angles.add_yaw(-delta.x);
-                    transform.eye -= delta.y * forward_vector;
+                    transform.eye += delta.y * look_vector;
                 }
                 ControlEvent::Rotate(delta) => {
                     // Rotates with pitch and yaw.
@@ -193,8 +265,11 @@ pub fn control_system(
                     look_angles.add_pitch(-delta.y);
                 }
                 ControlEvent::TranslateEye(delta) => {
+                    let yaw_rot = Quat::from_axis_angle(Vec3::Y, look_angles.get_yaw());
+                    let rot_x = yaw_rot * Vec3::X;
+
                     // Translates up/down (Y) and left/right (X).
-                    transform.eye -= delta.x * rot_x + delta.y * rot_y;
+                    transform.eye -= delta.x * rot_x - Vec3::new(0.0, delta.y, 0.0);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,18 +72,24 @@
 //!
 //! These plugins depend on the `LookTransformPlugin`:
 //!
-//! - `FpsCameraPlugin + FpsCameraBundle`
+//! - `FpsCameraPlugin` + `FpsCameraBundle`
 //!   - WASD: Translate on the XZ plane
 //!   - Shift/Space: Translate along the Y axis
 //!   - Mouse: Rotate camera
-//! - `OrbitCameraPlugin + OrbitCameraBundle`
+//! - `OrbitCameraPlugin` + `OrbitCameraBundle`
 //!   - CTRL + mouse drag: Rotate camera
 //!   - Right mouse drag: Pan camera
 //!   - Mouse wheel: Zoom
-//! - `UnrealCameraPlugin + UnrealCameraBundle`
+//! - `UnrealCameraPlugin` + `UnrealCameraBundle`
+//!   Best use: hold Right mouse button to orbit the view while using WASD to navigate in the scene,
+//!   using scroll wheel to accelerate/decelerate.
 //!   - Left mouse drag: Locomotion
 //!   - Right mouse drag: Rotate camera
-//!   - Left and Right mouse drag: Pan camera
+//!   - Left and Right or Middle mouse drag: Pan camera
+//!   - While holding any mouse button, use A/D for panning left/right, Q/E for panning up/down
+//!   - While holding any mouse button, use W/S for locomotion forward/backward
+//!   - While holding any mouse button, use scroll wheel to increase/decrease locomotion and panning speeds
+//!   - While holding no mouse button, use scroll wheel for locomotion forward/backward
 
 pub mod controllers;
 


### PR DESCRIPTION
Hello, and first of all: thank you for this plugin, awesome work and very useful/readable.

I'm using  Unreal Editor 4.27 in my day-to-day job, and your mapping for the "Unreal" camera were not exactly mimicking UE4 perspective viewport controls.

I've modified your `unreal` module to follow them more closely. I've also tuned the default values of the `UnrealCameraController` to have better default speeds compared to the Bevy unit. They feel better when navigating in a scene with meshes of diameter 1 but we might want to put them back up if that's not the ordinary case. They just felt better for the `simple_unreal.rs` example!

Please don't hesitate to comment/review my code :)