### PR TITLE
Allow pausing interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Enables the system that synchronizes your `Transform`s and `LookTransform`s.
         .add_plugin(LookTransformPlugin)
-        .add_startup_system(setup.system())
-        .add_system(move_camera_system.system());
+        .add_startup_system(setup)
+        .add_system(move_camera_system);
 }
 
 fn setup(mut commands: Commands) {
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands) {
 
     commands
         .spawn_bundle(LookTransformBundle {
-            transform: LookTransform { eye, target },
+            transform: LookTransform::new(eye, target),
             smoother: Smoother::new(0.9), // Value between 0.0 and 1.0, higher is smoother.
         })
         .insert_bundle(PerspectiveCameraBundle::default());

--- a/examples/simple_look_transform.rs
+++ b/examples/simple_look_transform.rs
@@ -39,12 +39,15 @@ fn setup(
 
     commands
         .spawn_bundle(LookTransformBundle {
-            transform: LookTransform::new(Vec3::new(-2.0, 2.5, 5.0), Vec3::new(0.0, 0.5, 0.0)),
+            transform: LookTransform {
+                eye: Vec3::new(-2.0, 2.5, 5.0),
+                target: Vec3::new(0.0, 0.5, 0.0),
+            },
             smoother: Smoother::new(0.9),
         })
         .insert_bundle(PerspectiveCameraBundle {
             transform: Transform::from_xyz(-2.0, 2.5, 5.0)
                 .looking_at(Vec3::new(0.0, 0.5, 0.0), Vec3::Y),
-            ..Default::default()
+            ..default()
         });
 }

--- a/examples/simple_look_transform.rs
+++ b/examples/simple_look_transform.rs
@@ -39,10 +39,7 @@ fn setup(
 
     commands
         .spawn_bundle(LookTransformBundle {
-            transform: LookTransform {
-                eye: Vec3::new(-2.0, 2.5, 5.0),
-                target: Vec3::new(0.0, 0.5, 0.0),
-            },
+            transform: LookTransform::new(Vec3::new(-2.0, 2.5, 5.0), Vec3::new(0.0, 0.5, 0.0)),
             smoother: Smoother::new(0.9),
         })
         .insert_bundle(PerspectiveCameraBundle {

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -1,3 +1,17 @@
+#[macro_use]
+mod macros {
+    #[macro_export]
+    macro_rules! define_on_controller_enabled_changed(($ControllerStruct:ty) => {
+        fn on_controller_enabled_changed(
+            mut look_transforms: Query<(&mut LookTransform, &$ControllerStruct), Changed<$ControllerStruct>>,
+        ) {
+            for (mut look_tfm, controller) in look_transforms.iter_mut() {
+                look_tfm.enabled = controller.enabled;
+            }
+        }
+    });
+}
+
 pub mod fps;
 pub mod orbit;
 pub mod unreal;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -3,10 +3,10 @@ mod macros {
     #[macro_export]
     macro_rules! define_on_controller_enabled_changed(($ControllerStruct:ty) => {
         fn on_controller_enabled_changed(
-            mut look_transforms: Query<(&mut LookTransform, &$ControllerStruct), Changed<$ControllerStruct>>,
+            mut smoothers: Query<(&mut Smoother, &$ControllerStruct), Changed<$ControllerStruct>>,
         ) {
-            for (mut look_tfm, controller) in look_transforms.iter_mut() {
-                look_tfm.enabled = controller.enabled;
+            for (mut smoother, controller) in smoothers.iter_mut() {
+                smoother.set_enabled(controller.enabled);
             }
         }
     });

--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -91,16 +91,7 @@ pub enum ControlEvent {
     TranslateEye(Vec3),
 }
 
-fn on_controller_enabled_changed(
-    mut look_transforms: Query<
-        (&mut LookTransform, &FpsCameraController),
-        Changed<FpsCameraController>,
-    >,
-) {
-    for (mut look_tfm, controller) in look_transforms.iter_mut() {
-        look_tfm.enabled = controller.enabled;
-    }
-}
+define_on_controller_enabled_changed!(FpsCameraController);
 
 pub fn default_input_map(
     mut events: EventWriter<ControlEvent>,

--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -99,16 +99,7 @@ pub enum ControlEvent {
     Zoom(f32),
 }
 
-fn on_controller_enabled_changed(
-    mut look_transforms: Query<
-        (&mut LookTransform, &OrbitCameraController),
-        Changed<OrbitCameraController>,
-    >,
-) {
-    for (mut look_tfm, controller) in look_transforms.iter_mut() {
-        look_tfm.enabled = controller.enabled;
-    }
-}
+define_on_controller_enabled_changed!(OrbitCameraController);
 
 pub fn default_input_map(
     mut events: EventWriter<ControlEvent>,

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -114,16 +114,7 @@ pub enum ControlEvent {
     TranslateEye(Vec2),
 }
 
-fn on_controller_enabled_changed(
-    mut look_transforms: Query<
-        (&mut LookTransform, &UnrealCameraController),
-        Changed<UnrealCameraController>,
-    >,
-) {
-    for (mut look_tfm, controller) in look_transforms.iter_mut() {
-        look_tfm.enabled = controller.enabled;
-    }
-}
+define_on_controller_enabled_changed!(UnrealCameraController);
 
 pub fn default_input_map(
     mut events: EventWriter<ControlEvent>,

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -28,7 +28,10 @@ impl UnrealCameraPlugin {
 
 impl Plugin for UnrealCameraPlugin {
     fn build(&self, app: &mut App) {
-        let app = app.add_system(control_system).add_event::<ControlEvent>();
+        let app = app
+            .add_system_to_stage(CoreStage::PreUpdate, on_controller_enabled_changed)
+            .add_system(control_system)
+            .add_event::<ControlEvent>();
         if !self.override_input_system {
             app.add_system(default_input_map);
         }
@@ -57,7 +60,7 @@ impl UnrealCameraBundle {
         Self {
             controller,
             look_transform: LookTransformBundle {
-                transform: LookTransform { eye, target },
+                transform: LookTransform::new(eye, target),
                 smoother: Smoother::new(controller.smoothing_weight),
             },
             perspective,
@@ -111,6 +114,17 @@ pub enum ControlEvent {
     TranslateEye(Vec2),
 }
 
+fn on_controller_enabled_changed(
+    mut look_transforms: Query<
+        (&mut LookTransform, &UnrealCameraController),
+        Changed<UnrealCameraController>,
+    >,
+) {
+    for (mut look_tfm, controller) in look_transforms.iter_mut() {
+        look_tfm.enabled = controller.enabled;
+    }
+}
+
 pub fn default_input_map(
     mut events: EventWriter<ControlEvent>,
     mut mouse_wheel_reader: EventReader<MouseWheel>,
@@ -120,9 +134,7 @@ pub fn default_input_map(
     mut controllers: Query<&mut UnrealCameraController>,
 ) {
     // Can only control one camera at a time.
-    let mut controller = if let Some(controller) = controllers.iter_mut().find(|c| {
-        c.enabled
-    }) {
+    let mut controller = if let Some(controller) = controllers.iter_mut().find(|c| c.enabled) {
         controller
     } else {
         return;
@@ -234,45 +246,42 @@ pub fn control_system(
     mut cameras: Query<(&UnrealCameraController, &mut LookTransform)>,
 ) {
     // Can only control one camera at a time.
-    let mut transform =
-        if let Some((_, transform)) = cameras.iter_mut().find(|c| {
-            c.0.enabled
-        }) {
-            transform
-        } else {
-            return;
-        };
+    let mut transform = if let Some((_, transform)) = cameras.iter_mut().find(|c| c.0.enabled) {
+        transform
+    } else {
+        return;
+    };
 
-        let look_vector;
-        match transform.look_direction() {
-            Some(safe_look_vector) => look_vector = safe_look_vector,
-            None => return,
-        }
-        let mut look_angles = LookAngles::from_vector(look_vector);
+    let look_vector;
+    match transform.look_direction() {
+        Some(safe_look_vector) => look_vector = safe_look_vector,
+        None => return,
+    }
+    let mut look_angles = LookAngles::from_vector(look_vector);
 
-        for event in events.iter() {
-            match event {
-                ControlEvent::Locomotion(delta) => {
-                    // Translates forward/backward and rotates about the Y axis.
-                    look_angles.add_yaw(-delta.x);
-                    transform.eye += delta.y * look_vector;
-                }
-                ControlEvent::Rotate(delta) => {
-                    // Rotates with pitch and yaw.
-                    look_angles.add_yaw(-delta.x);
-                    look_angles.add_pitch(-delta.y);
-                }
-                ControlEvent::TranslateEye(delta) => {
-                    let yaw_rot = Quat::from_axis_angle(Vec3::Y, look_angles.get_yaw());
-                    let rot_x = yaw_rot * Vec3::X;
+    for event in events.iter() {
+        match event {
+            ControlEvent::Locomotion(delta) => {
+                // Translates forward/backward and rotates about the Y axis.
+                look_angles.add_yaw(-delta.x);
+                transform.eye += delta.y * look_vector;
+            }
+            ControlEvent::Rotate(delta) => {
+                // Rotates with pitch and yaw.
+                look_angles.add_yaw(-delta.x);
+                look_angles.add_pitch(-delta.y);
+            }
+            ControlEvent::TranslateEye(delta) => {
+                let yaw_rot = Quat::from_axis_angle(Vec3::Y, look_angles.get_yaw());
+                let rot_x = yaw_rot * Vec3::X;
 
-                    // Translates up/down (Y) and left/right (X).
-                    transform.eye -= delta.x * rot_x - Vec3::new(0.0, delta.y, 0.0);
-                }
+                // Translates up/down (Y) and left/right (X).
+                transform.eye -= delta.x * rot_x - Vec3::new(0.0, delta.y, 0.0);
             }
         }
+    }
 
-        look_angles.assert_not_looking_up();
+    look_angles.assert_not_looking_up();
 
-        transform.target = transform.eye + transform.radius() * look_angles.unit_vector();
+    transform.target = transform.eye + transform.radius() * look_angles.unit_vector();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //!     commands
 //!         .spawn_bundle(LookTransformBundle {
-//!             transform: LookTransform { eye, target },
+//!             transform: LookTransform::new(eye, target),
 //!             smoother: Smoother::new(0.9), // Value between 0.0 and 1.0, higher is smoother.
 //!         })
 //!         .insert_bundle(PerspectiveCameraBundle::default());

--- a/src/look_transform.rs
+++ b/src/look_transform.rs
@@ -25,13 +25,12 @@ pub struct LookTransformBundle {
 pub struct LookTransform {
     pub eye: Vec3,
     pub target: Vec3,
-    pub up: Vec3,
     pub(crate) enabled: bool,
 }
 
 impl From<LookTransform> for Transform {
     fn from(t: LookTransform) -> Self {
-        eye_look_at_target_transform(t.eye, t.target, t.up)
+        eye_look_at_target_transform(t.eye, t.target)
     }
 }
 
@@ -40,7 +39,6 @@ impl LookTransform {
         Self {
             eye,
             target,
-            up: Vec3::Y,
             enabled: true,
         }
     }
@@ -54,12 +52,12 @@ impl LookTransform {
     }
 }
 
-fn eye_look_at_target_transform(eye: Vec3, target: Vec3, up: Vec3) -> Transform {
+fn eye_look_at_target_transform(eye: Vec3, target: Vec3) -> Transform {
     // If eye and target are very close, we avoid imprecision issues by keeping the look vector a unit vector.
     let look_vector = (target - eye).normalize();
     let look_at = eye + look_vector;
 
-    Transform::from_translation(eye).looking_at(look_at, up)
+    Transform::from_translation(eye).looking_at(look_at, Vec3::Y)
 }
 
 /// Preforms exponential smoothing on a `LookTransform`. Set the `lag_weight` between `0.0` and `1.0`, where higher is smoother.


### PR DESCRIPTION
Hello! Me again 😅

This PR is to allow external systems to pause the automatic smoothing and let them control the LookTransform themselves. When they give back control, the smoother shouldn't animate either. Finally, it fixes the "up" vector always set to Vec::Y for all LookTransform. Indeed, the resulting transform from external systems might have another up vector and we shouldn't break continuity when getting the control back.

Note that this branch builds upon my other PR #11 to update bevy.
