### PR TITLE
Reduce bevy dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.7"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
-features = ["render"]
+features = ["bevy_render"]
 default-features = false
 
 [dev-dependencies.bevy]
@@ -25,7 +25,7 @@ version = "0.7"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
-features = ["bevy_winit", "bevy_gltf"]
+features = ["bevy_core_pipeline", "bevy_pbr", "bevy_winit", "bevy_gltf"]
 default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202