### PR TITLE
Remove dependency on bevy_render

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.7"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
-features = ["bevy_render"]
 default-features = false
 
 [dev-dependencies.bevy]
@@ -25,7 +24,7 @@ version = "0.7"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
-features = ["bevy_core_pipeline", "bevy_pbr", "bevy_winit", "bevy_gltf"]
+features = ["bevy_core_pipeline", "bevy_pbr", "bevy_winit", "bevy_gltf", "bevy_render"]
 default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]

--- a/examples/simple_fps.rs
+++ b/examples/simple_fps.rs
@@ -41,10 +41,11 @@ fn setup(
         ..Default::default()
     });
 
-    commands.spawn_bundle(FpsCameraBundle::new(
-        FpsCameraController::default(),
-        PerspectiveCameraBundle::default(),
-        Vec3::new(-2.0, 5.0, 5.0),
-        Vec3::new(0., 0., 0.),
-    ));
+    commands
+        .spawn_bundle(PerspectiveCameraBundle::default())
+        .insert_bundle(FpsCameraBundle::new(
+            FpsCameraController::default(),
+            Vec3::new(-2.0, 5.0, 5.0),
+            Vec3::new(0., 0., 0.),
+        ));
 }

--- a/examples/simple_orbit.rs
+++ b/examples/simple_orbit.rs
@@ -41,10 +41,11 @@ fn setup(
         ..Default::default()
     });
 
-    commands.spawn_bundle(OrbitCameraBundle::new(
-        OrbitCameraController::default(),
-        PerspectiveCameraBundle::default(),
-        Vec3::new(-2.0, 5.0, 5.0),
-        Vec3::new(0., 0., 0.),
-    ));
+    commands
+        .spawn_bundle(PerspectiveCameraBundle::default())
+        .insert_bundle(OrbitCameraBundle::new(
+            OrbitCameraController::default(),
+            Vec3::new(-2.0, 5.0, 5.0),
+            Vec3::new(0., 0., 0.),
+        ));
 }

--- a/examples/simple_unreal.rs
+++ b/examples/simple_unreal.rs
@@ -41,10 +41,11 @@ fn setup(
         ..Default::default()
     });
 
-    commands.spawn_bundle(UnrealCameraBundle::new(
-        UnrealCameraController::default(),
-        PerspectiveCameraBundle::default(),
-        Vec3::new(-2.0, 5.0, 5.0),
-        Vec3::new(0., 0., 0.),
-    ));
+    commands
+        .spawn_bundle(PerspectiveCameraBundle::default())
+        .insert_bundle(UnrealCameraBundle::new(
+            UnrealCameraController::default(),
+            Vec3::new(-2.0, 5.0, 5.0),
+            Vec3::new(0., 0., 0.),
+        ));
 }

--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -5,7 +5,6 @@ use bevy::{
     ecs::{bundle::Bundle, prelude::*},
     input::{mouse::MouseMotion, prelude::*},
     math::prelude::*,
-    render::{camera::Camera3d, prelude::*},
     transform::components::Transform,
 };
 use serde::{Deserialize, Serialize};
@@ -41,19 +40,17 @@ pub struct FpsCameraBundle {
     controller: FpsCameraController,
     #[bundle]
     look_transform: LookTransformBundle,
-    #[bundle]
-    perspective: PerspectiveCameraBundle<Camera3d>,
+    transform: Transform,
 }
 
 impl FpsCameraBundle {
     pub fn new(
         controller: FpsCameraController,
-        mut perspective: PerspectiveCameraBundle<Camera3d>,
         eye: Vec3,
         target: Vec3,
     ) -> Self {
         // Make sure the transform is consistent with the controller to start.
-        perspective.transform = Transform::from_translation(eye).looking_at(target, Vec3::Y);
+        let transform = Transform::from_translation(eye).looking_at(target, Vec3::Y);
 
         Self {
             controller,
@@ -61,7 +58,7 @@ impl FpsCameraBundle {
                 transform: LookTransform::new(eye, target),
                 smoother: Smoother::new(controller.smoothing_weight),
             },
-            perspective,
+            transform,
         }
     }
 }

--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -8,7 +8,6 @@ use bevy::{
         prelude::*,
     },
     math::prelude::*,
-    render::{camera::Camera3d, prelude::*},
     transform::components::Transform,
 };
 use serde::{Deserialize, Serialize};
@@ -44,19 +43,17 @@ pub struct OrbitCameraBundle {
     controller: OrbitCameraController,
     #[bundle]
     look_transform: LookTransformBundle,
-    #[bundle]
-    perspective: PerspectiveCameraBundle<Camera3d>,
+    transform: Transform,
 }
 
 impl OrbitCameraBundle {
     pub fn new(
         controller: OrbitCameraController,
-        mut perspective: PerspectiveCameraBundle<Camera3d>,
         eye: Vec3,
         target: Vec3,
     ) -> Self {
         // Make sure the transform is consistent with the controller to start.
-        perspective.transform = Transform::from_translation(eye).looking_at(target, Vec3::Y);
+        let transform = Transform::from_translation(eye).looking_at(target, Vec3::Y);
 
         Self {
             controller,
@@ -64,7 +61,7 @@ impl OrbitCameraBundle {
                 transform: LookTransform::new(eye, target),
                 smoother: Smoother::new(controller.smoothing_weight),
             },
-            perspective,
+            transform,
         }
     }
 }

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -8,7 +8,6 @@ use bevy::{
         prelude::*,
     },
     math::prelude::*,
-    render::{camera::Camera3d, prelude::*},
     transform::components::Transform,
 };
 use serde::{Deserialize, Serialize};
@@ -43,19 +42,13 @@ pub struct UnrealCameraBundle {
     controller: UnrealCameraController,
     #[bundle]
     look_transform: LookTransformBundle,
-    #[bundle]
-    perspective: PerspectiveCameraBundle<Camera3d>,
+    transform: Transform,
 }
 
 impl UnrealCameraBundle {
-    pub fn new(
-        controller: UnrealCameraController,
-        mut perspective: PerspectiveCameraBundle<Camera3d>,
-        eye: Vec3,
-        target: Vec3,
-    ) -> Self {
+    pub fn new(controller: UnrealCameraController, eye: Vec3, target: Vec3) -> Self {
         // Make sure the transform is consistent with the controller to start.
-        perspective.transform = Transform::from_translation(eye).looking_at(target, Vec3::Y);
+        let transform = Transform::from_translation(eye).looking_at(target, Vec3::Y);
 
         Self {
             controller,
@@ -63,7 +56,7 @@ impl UnrealCameraBundle {
                 transform: LookTransform::new(eye, target),
                 smoother: Smoother::new(controller.smoothing_weight),
             },
-            perspective,
+            transform,
         }
     }
 }


### PR DESCRIPTION
This separates the `PerspectiveCameraBundle` from `bevy_render` and `OrbitCameraBundle` `UnrealCameraBundle` `FpsCameraBundle` so that this could be used with applications with custom rendering backend.