### PR TITLE
Fix target translation bug in orbital camera

### DIFF
--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -159,6 +159,7 @@ pub fn control_system(
 
     let mut look_angles = LookAngles::from_vector(-transform.look_direction().unwrap());
     let mut radius_scalar = 1.0;
+    let radius = transform.radius();
 
     let dt = time.delta_seconds();
     for event in events.iter() {
@@ -180,8 +181,6 @@ pub fn control_system(
 
     look_angles.assert_not_looking_up();
 
-    let new_radius = (radius_scalar * transform.radius())
-        .min(1000000.0)
-        .max(0.001);
+    let new_radius = (radius_scalar * radius).min(1000000.0).max(0.001);
     transform.eye = transform.target + new_radius * look_angles.unit_vector();
 }


### PR DESCRIPTION
Hello, while using the orbital camera I noticed a small bug.

When translating the target there is a very small zoom out effect. It is barely noticeable but over time it will build up. The video below shows the radius increasing when i pan the camera.


https://github.com/bonsairobo/smooth-bevy-cameras/assets/17007091/11fbbb82-3eae-4028-8996-3a74f08e3873



The issue is that the `new_radius` calculation in the `control_system` is done using the new transform after it has been panned meaning that the radius will be slightly larger than previously so when the eye is transformed back to the same angle it will keep the longer radius.

The result of the PR is shown in the video below (where the radius is no longer increased when panning).


https://github.com/bonsairobo/smooth-bevy-cameras/assets/17007091/a8c349f9-ebfe-4302-90af-f841bdd658c9

