### PR TITLE
Implemented appropriate reflections

### DIFF
--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -5,8 +5,10 @@ use bevy::{
     ecs::prelude::*,
     input::{mouse::MouseMotion, prelude::*},
     math::prelude::*,
+    prelude::ReflectDefault,
+    reflect::Reflect,
     time::Time,
-    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
+    transform::components::Transform,
 };
 
 #[derive(Default)]

--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -2,11 +2,11 @@ use crate::{LookAngles, LookTransform, LookTransformBundle, Smoother};
 
 use bevy::{
     app::prelude::*,
-    ecs::{bundle::Bundle, prelude::*},
+    ecs::prelude::*,
     input::{mouse::MouseMotion, prelude::*},
     math::prelude::*,
     time::Time,
-    transform::components::Transform,
+    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
 };
 
 #[derive(Default)]
@@ -59,8 +59,9 @@ impl FpsCameraBundle {
 }
 
 /// Your typical first-person camera controller.
-#[derive(Clone, Component, Copy, Debug)]
+#[derive(Clone, Component, Copy, Debug, Reflect)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[reflect(Component, Default, Debug)]
 pub struct FpsCameraController {
     pub enabled: bool,
     pub mouse_rotate_sensitivity: Vec2,

--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -8,8 +8,10 @@ use bevy::{
         prelude::*,
     },
     math::prelude::*,
+    prelude::ReflectDefault,
+    reflect::Reflect,
     time::Time,
-    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
+    transform::components::Transform,
 };
 
 #[derive(Default)]

--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -9,7 +9,7 @@ use bevy::{
     },
     math::prelude::*,
     time::Time,
-    transform::components::Transform,
+    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
 };
 
 #[derive(Default)]
@@ -62,8 +62,9 @@ impl OrbitCameraBundle {
 }
 
 /// A 3rd person camera that orbits around the target.
-#[derive(Clone, Component, Copy, Debug)]
+#[derive(Clone, Component, Copy, Debug, Reflect)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[reflect(Component, Default, Debug)]
 pub struct OrbitCameraController {
     pub enabled: bool,
     pub mouse_rotate_sensitivity: Vec2,

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -9,7 +9,7 @@ use bevy::{
     },
     math::prelude::*,
     time::Time,
-    transform::components::Transform,
+    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
 };
 
 #[derive(Default)]
@@ -61,8 +61,9 @@ impl UnrealCameraBundle {
 }
 
 /// A camera controlled with the mouse in the same way as Unreal Engine's viewport controller.
-#[derive(Clone, Component, Copy, Debug)]
+#[derive(Clone, Component, Copy, Debug, Reflect)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[reflect(Component, Default, Debug)]
 pub struct UnrealCameraController {
     /// Whether to process input or ignore it
     pub enabled: bool,

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -8,8 +8,10 @@ use bevy::{
         prelude::*,
     },
     math::prelude::*,
+    prelude::ReflectDefault,
+    reflect::Reflect,
     time::Time,
-    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
+    transform::components::Transform,
 };
 
 #[derive(Default)]

--- a/src/look_angles.rs
+++ b/src/look_angles.rs
@@ -1,11 +1,12 @@
 use approx::relative_eq;
-use bevy::{math::prelude::*, reflect::Reflect, prelude::ReflectDefault};
+use bevy::{math::prelude::*, prelude::ReflectDefault, reflect::Reflect};
 
 const PI: f32 = std::f32::consts::PI;
 
 /// A (yaw, pitch) pair representing a direction.
-#[derive(Clone, Copy, Debug, Default, Reflect)]
-#[reflect(Debug, Default)]
+#[derive(Debug, PartialEq, Clone, Copy, Default, Reflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[reflect(Default, Debug, PartialEq)]
 pub struct LookAngles {
     // The fields are protected to keep them in an allowable range for the camera transform.
     yaw: f32,

--- a/src/look_angles.rs
+++ b/src/look_angles.rs
@@ -1,10 +1,11 @@
 use approx::relative_eq;
-use bevy::math::prelude::*;
+use bevy::{math::prelude::*, reflect::Reflect, prelude::ReflectDefault};
 
 const PI: f32 = std::f32::consts::PI;
 
 /// A (yaw, pitch) pair representing a direction.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Reflect)]
+#[reflect(Debug, Default)]
 pub struct LookAngles {
     // The fields are protected to keep them in an allowable range for the camera transform.
     yaw: f32,

--- a/src/look_angles.rs
+++ b/src/look_angles.rs
@@ -5,7 +5,7 @@ const PI: f32 = std::f32::consts::PI;
 
 /// A (yaw, pitch) pair representing a direction.
 #[derive(Debug, PartialEq, Clone, Copy, Default, Reflect)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Default, Debug, PartialEq)]
 pub struct LookAngles {
     // The fields are protected to keep them in an allowable range for the camera transform.

--- a/src/look_transform.rs
+++ b/src/look_transform.rs
@@ -20,7 +20,7 @@ pub struct LookTransformBundle {
 /// An eye and the target it's looking at. As a component, this can be modified in place of bevy's `Transform`, and the two will
 /// stay in sync.
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component, Default, Debug, PartialEq)]
 pub struct LookTransform {
     pub eye: Vec3,
@@ -68,7 +68,7 @@ fn eye_look_at_target_transform(eye: Vec3, target: Vec3, up: Vec3) -> Transform 
 
 /// Preforms exponential smoothing on a `LookTransform`. Set the `lag_weight` between `0.0` and `1.0`, where higher is smoother.
 #[derive(Clone, Component, Copy, Debug, Reflect)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component, Default, Debug)]
 pub struct Smoother {
     lag_weight: f32,

--- a/src/look_transform.rs
+++ b/src/look_transform.rs
@@ -1,8 +1,6 @@
 use bevy::{
-    app::prelude::*,
-    ecs::prelude::*,
-    math::prelude::*,
-    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
+    app::prelude::*, ecs::prelude::*, math::prelude::*, prelude::ReflectDefault, reflect::Reflect,
+    transform::components::Transform,
 };
 
 pub struct LookTransformPlugin;
@@ -21,8 +19,9 @@ pub struct LookTransformBundle {
 
 /// An eye and the target it's looking at. As a component, this can be modified in place of bevy's `Transform`, and the two will
 /// stay in sync.
-#[derive(Clone, Component, Copy, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[reflect(Component, Default, Debug, PartialEq)]
 pub struct LookTransform {
     pub eye: Vec3,
     pub target: Vec3,
@@ -37,7 +36,11 @@ impl From<LookTransform> for Transform {
 
 impl Default for LookTransform {
     fn default() -> Self {
-        Self { eye: Vec3::default(), target: Vec3::default(), up: Vec3::Y }
+        Self {
+            eye: Vec3::default(),
+            target: Vec3::default(),
+            up: Vec3::Y,
+        }
     }
 }
 
@@ -65,6 +68,7 @@ fn eye_look_at_target_transform(eye: Vec3, target: Vec3, up: Vec3) -> Transform 
 
 /// Preforms exponential smoothing on a `LookTransform`. Set the `lag_weight` between `0.0` and `1.0`, where higher is smoother.
 #[derive(Clone, Component, Copy, Debug, Reflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component, Default, Debug)]
 pub struct Smoother {
     lag_weight: f32,
@@ -74,7 +78,11 @@ pub struct Smoother {
 
 impl Default for Smoother {
     fn default() -> Self {
-        Self { lag_weight: 0.9, lerp_tfm: Some(LookTransform::default()), enabled: true }
+        Self {
+            lag_weight: 0.9,
+            lerp_tfm: Some(LookTransform::default()),
+            enabled: true,
+        }
     }
 }
 

--- a/src/look_transform.rs
+++ b/src/look_transform.rs
@@ -1,8 +1,8 @@
 use bevy::{
     app::prelude::*,
-    ecs::{bundle::Bundle, prelude::*},
+    ecs::prelude::*,
     math::prelude::*,
-    transform::components::Transform,
+    transform::components::Transform, reflect::Reflect, prelude::ReflectDefault,
 };
 
 pub struct LookTransformPlugin;
@@ -21,7 +21,8 @@ pub struct LookTransformBundle {
 
 /// An eye and the target it's looking at. As a component, this can be modified in place of bevy's `Transform`, and the two will
 /// stay in sync.
-#[derive(Clone, Component, Copy, Debug)]
+#[derive(Clone, Component, Copy, Debug, Reflect)]
+#[reflect(Component, Default, Debug)]
 pub struct LookTransform {
     pub eye: Vec3,
     pub target: Vec3,
@@ -31,6 +32,12 @@ pub struct LookTransform {
 impl From<LookTransform> for Transform {
     fn from(t: LookTransform) -> Self {
         eye_look_at_target_transform(t.eye, t.target, t.up)
+    }
+}
+
+impl Default for LookTransform {
+    fn default() -> Self {
+        Self { eye: Vec3::default(), target: Vec3::default(), up: Vec3::Y }
     }
 }
 
@@ -57,11 +64,18 @@ fn eye_look_at_target_transform(eye: Vec3, target: Vec3, up: Vec3) -> Transform 
 }
 
 /// Preforms exponential smoothing on a `LookTransform`. Set the `lag_weight` between `0.0` and `1.0`, where higher is smoother.
-#[derive(Component, Clone)]
+#[derive(Clone, Component, Copy, Debug, Reflect)]
+#[reflect(Component, Default, Debug)]
 pub struct Smoother {
     lag_weight: f32,
     lerp_tfm: Option<LookTransform>,
     enabled: bool,
+}
+
+impl Default for Smoother {
+    fn default() -> Self {
+        Self { lag_weight: 0.9, lerp_tfm: Some(LookTransform::default()), enabled: true }
+    }
 }
 
 impl Smoother {


### PR DESCRIPTION
As discussed in #39 

Cargo.toml
```toml
[package]
name = "reflect-example"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
bevy = "0.11.3"
bevy-inspector-egui = "0.19.0"
smooth-bevy-cameras = { git = "https://github.com/kylemiller3/smooth-bevy-cameras.git"}
```

main.rs
```rs
use bevy::prelude::*;
use bevy_inspector_egui::quick::WorldInspectorPlugin;
use smooth_bevy_cameras::{LookTransformPlugin, controllers::{fps::{FpsCameraBundle, FpsCameraController}, orbit::OrbitCameraController, unreal::UnrealCameraController}, LookTransform, LookAngles, Smoother};

fn main() {
    App::new()
        .add_plugins((DefaultPlugins, LookTransformPlugin, WorldInspectorPlugin::new()))
        .add_systems(Startup, setup)
        .register_type::<LookTransform>()
        .register_type::<LookAngles>()
        .register_type::<Smoother>()
        .register_type::<FpsCameraController>()
        .register_type::<OrbitCameraController>()
        .register_type::<UnrealCameraController>()
        .run()
}

fn setup(mut commands: Commands) {
    let eye = Vec3::default();
    let target = Vec3::default();
    let up = Vec3::Y;
    let controller = FpsCameraController::default();

    commands.spawn(FpsCameraBundle::new(controller, eye, target, up));
}
```

Without Reflect:

<img width="1392" alt="image" src="https://github.com/bonsairobo/smooth-bevy-cameras/assets/5983525/0a138fb5-b3f0-41a1-a13d-6c89f7ae1350">


With Reflect:

<img width="1392" alt="image" src="https://github.com/bonsairobo/smooth-bevy-cameras/assets/5983525/767f4537-1248-454f-8992-b12b157f5396">

Might want to review my default implementations needed for reflect. Not sure what sane defaults should be.