### PR TITLE
Update to Bevy 0.14, Rust 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smooth-bevy-cameras"
 description = "Bevy camera controllers with buttery, exponential smoothing."
-version = "0.11.0"
+version = "0.12.0"
 repository = "https://github.com/bonsairobo/smooth-bevy-cameras"
 authors = ["Duncan <bonsairobo@gmail.com>"]
 keywords = ["bevy", "camera"]
@@ -14,14 +14,14 @@ approx = "0.5"
 serde = { version = "1.0", optional = true }
 
 [dependencies.bevy]
-version = "0.13"
+version = "0.14"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.13"
+version = "0.14"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
@@ -38,7 +38,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
-version = "0.13"
+version = "0.14"
 features = [
     "bevy_asset",
     "bevy_core_pipeline",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.76"
+channel = "1.79"


### PR DESCRIPTION
Updates to Bevy 0.14 and (as required by the new Bevy version) Rust 1.79. No code changes were required.