### PR TITLE
Update to Bevy 0.15, Rust 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smooth-bevy-cameras"
 description = "Bevy camera controllers with buttery, exponential smoothing."
-version = "0.12.0"
+version = "0.13.0"
 repository = "https://github.com/bonsairobo/smooth-bevy-cameras"
 authors = ["Duncan <bonsairobo@gmail.com>"]
 keywords = ["bevy", "camera"]
@@ -14,14 +14,14 @@ approx = "0.5"
 serde = { version = "1.0", optional = true }
 
 [dependencies.bevy]
-version = "0.14"
+version = "0.15"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.14"
+version = "0.15"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "f3de12bc"
 # branch = "main"
@@ -38,7 +38,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
-version = "0.14"
+version = "0.15"
 features = [
     "bevy_asset",
     "bevy_core_pipeline",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.79"
+channel = "1.82"

--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -154,7 +154,7 @@ pub fn control_system(
     let rot_y = yaw_rot * Vec3::Y;
     let rot_z = yaw_rot * Vec3::Z;
 
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
     for event in events.read() {
         match event {
             ControlEvent::Rotate(delta) => {

--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -164,7 +164,7 @@ pub fn control_system(
     let mut radius_scalar = 1.0;
     let radius = transform.radius();
 
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
     for event in events.read() {
         match event {
             ControlEvent::Orbit(delta) => {

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -247,7 +247,7 @@ pub fn control_system(
     };
     let mut look_angles = LookAngles::from_vector(look_vector);
 
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
     for event in events.read() {
         match event {
             ControlEvent::Locomotion(delta) => {


### PR DESCRIPTION
This PR makes the minimal changes necessary to support Bevy 0.15.

This version of Bevy moves away from Bundles and plugin owners are encouraged to replace their own bundles with the new Required Components architecture. However, that would break the API for smooth-bevy-cameras and requires some decision-making on how EG `OrbitCameraBundle::new()` should be handled with Required Components.

closes #49 