### PR TITLE
Update to Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.13.0"
 repository = "https://github.com/bonsairobo/smooth-bevy-cameras"
 authors = ["Duncan <bonsairobo@gmail.com>"]
 keywords = ["bevy", "camera"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [dependencies]
@@ -13,9 +13,9 @@ approx = "0.5"
 serde = { version = "1.0", optional = true }
 
 [dependencies.bevy]
-version = "0.15"
+version = "0.16"
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.15"
+version = "0.16"
 default-features = true

--- a/examples/simple_fps.rs
+++ b/examples/simple_fps.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use smooth_bevy_cameras::{
-    controllers::fps::{FpsCameraBundle, FpsCameraController, FpsCameraPlugin},
     LookTransformPlugin,
+    controllers::fps::{FpsCameraBundle, FpsCameraController, FpsCameraPlugin},
 };
 
 fn main() {

--- a/examples/simple_look_transform.rs
+++ b/examples/simple_look_transform.rs
@@ -46,8 +46,9 @@ fn setup(
             },
             smoother: Smoother::new(0.9),
         })
-        .insert((Camera3d::default(),
-                 Msaa::Sample4,
-                 Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::new(0.0, 0.5, 0.0), Vec3::Y)
+        .insert((
+            Camera3d::default(),
+            Msaa::Sample4,
+            Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::new(0.0, 0.5, 0.0), Vec3::Y),
         ));
 }

--- a/examples/simple_look_transform.rs
+++ b/examples/simple_look_transform.rs
@@ -3,7 +3,6 @@ use smooth_bevy_cameras::{LookTransform, LookTransformBundle, LookTransformPlugi
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
         .add_plugins(LookTransformPlugin)
         .add_systems(Startup, setup)
@@ -17,25 +16,26 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // plane
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(PlaneMeshBuilder::from_size(Vec2::splat(5.0)))),
-        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Mesh::from(PlaneMeshBuilder::from_size(Vec2::splat(5.0))))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
 
     // cube
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(Cuboid::from_size(Vec3::splat(1.0)))),
-        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Mesh::from(Cuboid::from_size(Vec3::splat(1.0))))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
 
     // light
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
 
     commands
         .spawn(LookTransformBundle {
@@ -46,9 +46,8 @@ fn setup(
             },
             smoother: Smoother::new(0.9),
         })
-        .insert(Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0)
-                .looking_at(Vec3::new(0.0, 0.5, 0.0), Vec3::Y),
-            ..default()
-        });
+        .insert((Camera3d::default(),
+                 Msaa::Sample4,
+                 Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::new(0.0, 0.5, 0.0), Vec3::Y)
+        ));
 }

--- a/examples/simple_orbit.rs
+++ b/examples/simple_orbit.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use smooth_bevy_cameras::{
-    controllers::orbit::{OrbitCameraBundle, OrbitCameraController, OrbitCameraPlugin},
     LookTransformPlugin,
+    controllers::orbit::{OrbitCameraBundle, OrbitCameraController, OrbitCameraPlugin},
 };
 
 fn main() {

--- a/examples/simple_unreal.rs
+++ b/examples/simple_unreal.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use smooth_bevy_cameras::{
-    controllers::unreal::{UnrealCameraBundle, UnrealCameraController, UnrealCameraPlugin},
     LookTransformPlugin,
+    controllers::unreal::{UnrealCameraBundle, UnrealCameraController, UnrealCameraPlugin},
 };
 
 fn main() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.82"
+channel = "1.85"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.82"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-profile = "default"
-channel = "1.82"

--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -113,7 +113,7 @@ pub fn default_input_map(
         cursor_delta += event.delta;
     }
 
-    events.send(ControlEvent::Rotate(
+    events.write(ControlEvent::Rotate(
         mouse_rotate_sensitivity * cursor_delta,
     ));
 
@@ -129,7 +129,7 @@ pub fn default_input_map(
     .cloned()
     {
         if keyboard.pressed(key) {
-            events.send(ControlEvent::TranslateEye(translate_sensitivity * dir));
+            events.write(ControlEvent::TranslateEye(translate_sensitivity * dir));
         }
     }
 }

--- a/src/controllers/orbit.rs
+++ b/src/controllers/orbit.rs
@@ -126,11 +126,11 @@ pub fn default_input_map(
     }
 
     if keyboard.pressed(KeyCode::ControlLeft) {
-        events.send(ControlEvent::Orbit(mouse_rotate_sensitivity * cursor_delta));
+        events.write(ControlEvent::Orbit(mouse_rotate_sensitivity * cursor_delta));
     }
 
     if mouse_buttons.pressed(MouseButton::Right) {
-        events.send(ControlEvent::TranslateTarget(
+        events.write(ControlEvent::TranslateTarget(
             mouse_translate_sensitivity * cursor_delta,
         ));
     }
@@ -144,7 +144,7 @@ pub fn default_input_map(
         };
         scalar *= 1.0 - scroll_amount * mouse_wheel_zoom_sensitivity;
     }
-    events.send(ControlEvent::Zoom(scalar));
+    events.write(ControlEvent::Zoom(scalar));
 }
 
 pub fn control_system(

--- a/src/controllers/unreal.rs
+++ b/src/controllers/unreal.rs
@@ -215,17 +215,17 @@ pub fn default_input_map(
     }
 
     if !left_pressed && !middle_pressed && right_pressed {
-        events.send(ControlEvent::Rotate(
+        events.write(ControlEvent::Rotate(
             mouse_rotate_sensitivity * cursor_delta,
         ));
     }
 
     if panning.length_squared() > 0.0 {
-        events.send(ControlEvent::TranslateEye(panning));
+        events.write(ControlEvent::TranslateEye(panning));
     }
 
     if locomotion.length_squared() > 0.0 {
-        events.send(ControlEvent::Locomotion(locomotion));
+        events.write(ControlEvent::Locomotion(locomotion));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,10 @@
 //!     let target = Vec3::default();
 //!
 //!     commands
-//!         .spawn(LookTransformBundle {
-//!             transform: LookTransform::new(eye, target, Vec3::Y),
-//!             smoother: Smoother::new(0.9), // Value between 0.0 and 1.0, higher is smoother.
-//!         })
-//!         .insert(Camera3dBundle::default());
+//!         .spawn((Camera3d::default(),
+//                  LookTransform::new(eye, target, Vec3::Y),
+//!                 Smoother::new(0.9), // Value between 0.0 and 1.0, higher is smoother.
+//!         ));
 //!
 //! }
 //!


### PR DESCRIPTION
Migrating the project to Bevy 0.16.

Note that in testing the examples, I spotted a few graphical regressions - they don't seem to be related to this crate specifically, and feel like rendering regressions in Bevy all up:

* Shadow of cube in `simple_fps`, `simple_orbit`, `simple_unreal` glitching / missing (depending on which WGPU backend you use). There are numerous reports of broken shadows in Bevy 0.16, so it is likely down to this
* Cube in `simple_fps`, `simple_orbit`, `simple_unreal` doesn't always display when running the examples. If you keep re-running the example, it eventually displays. Feels like a caching issue in the asset pipeline somewhere - again, probably unrelated to this crate specifically

All camera functionality tested and working