### PR TITLE
FPS optimize and toolchain change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ approx = "0.5"
 serde = { version = "1.0", optional = true }
 
 [dependencies.bevy]
-version = "0.17"
+version = "0.*"
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.17"
+version = "0.*"
 default-features = true

--- a/examples/simple_look_transform.rs
+++ b/examples/simple_look_transform.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, render::mesh::PlaneMeshBuilder};
+use bevy::prelude::*;
 use smooth_bevy_cameras::{LookTransform, LookTransformBundle, LookTransformPlugin, Smoother};
 
 fn main() {
@@ -17,7 +17,7 @@ fn setup(
 ) {
     // plane
     commands.spawn((
-        Mesh3d(meshes.add(Mesh::from(PlaneMeshBuilder::from_size(Vec2::splat(5.0))))),
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
         MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
     ));
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.85"
+channel = "stable"

--- a/src/controllers/fps.rs
+++ b/src/controllers/fps.rs
@@ -125,6 +125,7 @@ pub fn default_input_map(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut mouse_motion_messages: MessageReader<MouseMotion>,
     controllers: Query<&FpsCameraController>,
+    cursor_options: Single<&CursorOptions>,
 ) {
     // Can only control one camera at a time.
     let controller = if let Some(controller) = controllers.iter().find(|c| c.enabled) {
@@ -132,6 +133,10 @@ pub fn default_input_map(
     } else {
         return;
     };
+    
+    // Check if cursor is currently locked using the CursorOptions resource
+    let cursor_locked = cursor_options.grab_mode == CursorGrabMode::Locked;
+    
     let FpsCameraController {
         translate_sensitivity,
         mouse_rotate_sensitivity,
@@ -139,8 +144,11 @@ pub fn default_input_map(
     } = *controller;
 
     let mut cursor_delta = Vec2::ZERO;
-    for event in mouse_motion_messages.read() {
-        cursor_delta += event.delta;
+    // Only process mouse motion if cursor is locked
+    if cursor_locked {
+        for event in mouse_motion_messages.read() {
+            cursor_delta += event.delta;
+        }
     }
 
     messages.write(ControlMessage::Rotate(


### PR DESCRIPTION
use alt to lock and unlock fps camera's mouse cursor, which is locked by default