### PR TITLE
Migrates to bevy 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ approx = "0.5"
 serde = { version = "1.0", optional = true }
 
 [dependencies.bevy]
-version = "0.17"
+version = "0.18.0"
 default-features = false
+features = ["mouse", "keyboard"]
 
 [dev-dependencies.bevy]
-version = "0.17"
+version = "0.18.0"
 default-features = true

--- a/examples/simple_look_transform.rs
+++ b/examples/simple_look_transform.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, render::mesh::PlaneMeshBuilder};
+use bevy::{mesh::PlaneMeshBuilder, prelude::*};
 use smooth_bevy_cameras::{LookTransform, LookTransformBundle, LookTransformPlugin, Smoother};
 
 fn main() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.88"
+channel = "1.89.0"


### PR DESCRIPTION
Ran tests and found no breaking changes besides a namespace change.